### PR TITLE
Remove potential neighbor when chat starts

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -15,6 +15,7 @@
 </template>
 
 <script>
+import axios from 'axios';
 import PotentialNeighbor from '@/components/PotentialNeighbor';
 
 export default {
@@ -63,8 +64,9 @@ export default {
         .then(() => {
           channel.invite(potentialNeighborUniqueIdentity)
             .then(() => {
+              this.addPotentialNeighborToNeighbors(potentialNeighborUniqueIdentity);
               this.$router.push({name: 'Chat'});
-            })
+            });
         });
     },
     createChannel(newChannelData) {
@@ -79,6 +81,13 @@ export default {
         .then(channel => {
           this.joinChannel(channel, newChannelData.potentialNeighborUniqueIdentity);
         });
+    },
+    addPotentialNeighborToNeighbors(potentialNeighborUniqueIdentity) {
+      axios({
+        url: 'http://127.0.0.1:8000/user/add_neighbor/' + this.user.id,
+        data: {'neighbor_id': potentialNeighborUniqueIdentity},
+        method: 'PUT'
+      })
     },
     getlocation() {
       if (!navigator.geolocation) {

--- a/server/app/domain_logic/user.py
+++ b/server/app/domain_logic/user.py
@@ -63,20 +63,19 @@ def get_potential_neighbors(user_id: str) -> List[User]:
 
 def get_neighbors(user_id: str):
     """Get the collection of neighbors for a user."""
-    user = User.objects.get(unique_identity=user_id)
+    user = User.objects.get(id=user_id)
     return user.neighbors
 
 
 def add_neighbor(current_user_id: str, neighbor_id: str) -> None:
     """
     Adds a user to the tracked neighbors so they don't appear in potential neighbor queries.
-
-    Note that this is unidirectional and it does not update the neighbor to be joined with this user.
     """
-    user = User.objects.get(unique_identity=current_user_id)
+    user = User.objects.get(id=current_user_id)
     neighbor = User.objects.get(unique_identity=neighbor_id)
 
     user.update(add_to_set__neighbors=neighbor)
+    neighbor.update(add_to_set__neighbors=user)
 
 
 def black_list_neighbor(current_user_id: str, neighbor_id: str) -> None:
@@ -85,7 +84,7 @@ def black_list_neighbor(current_user_id: str, neighbor_id: str) -> None:
 
     Note that this is unidirectional and it does not update the neighbor to be joined with this user.
     """
-    user = User.objects.get(unique_identity=current_user_id)
+    user = User.objects.get(id=current_user_id)
     neighbor = User.objects.get(unique_identity=neighbor_id)
 
     user.update(pull__neighbors=neighbor)

--- a/server/app/routes/user.py
+++ b/server/app/routes/user.py
@@ -39,17 +39,15 @@ def get_neighbors(user_id: str):
     return jsonify([user_schema.dump(user) for user in users])
 
 
-@USER_BP.route('/add_neighbor', methods=['PUT'])
-def add_neighbor():
-    current_user_id = request.json['current_user_id']
+@USER_BP.route('/add_neighbor/<user_id>', methods=['PUT'])
+def add_neighbor(user_id: int):
     neighbor_id = request.json['neighbor_id']
-    user_domain_logic.add_neighbor(current_user_id, neighbor_id)
+    user_domain_logic.add_neighbor(user_id, neighbor_id)
     return "Updated successfully.", HTTPStatus.NO_CONTENT
 
 
-@USER_BP.route('/remove_neighbor', methods=['PUT'])
-def remove_neighbor():
-    current_user_id = request.json['current_user_id']
+@USER_BP.route('/remove_neighbor/<user_id>', methods=['PUT'])
+def remove_neighbor(user_id):
     neighbor_id = request.json['neighbor_id']
-    user_domain_logic.black_list_neighbor(current_user_id, neighbor_id)
+    user_domain_logic.black_list_neighbor(user_id, neighbor_id)
     return "Updated successfully.", HTTPStatus.NO_CONTENT

--- a/server/tests/integration_tests/test_get_nearby_users.py
+++ b/server/tests/integration_tests/test_get_nearby_users.py
@@ -30,14 +30,14 @@ def test_get_potential_neighbors_no_results(user, user2, user3, user4, login, cl
 def test_add_neighbor(user, user2, login, client):
     """Should return user 2."""
     client.put(
-        f'user/add_neighbor',
-        json=dict(current_user_id=user.unique_identity, neighbor_id=user2.unique_identity),
+        f'user/add_neighbor/{user.id}',
+        json=dict(neighbor_id=user2.unique_identity),
         content_type="application/json"
     )
 
     # Potential neighbors should be empty
     response = client.get(
-        f'user/nearby/{user.unique_identity}'
+        f'user/nearby/{user.id}'
     )
     response_json = json.loads(response.data)
     assert(len(response_json) == 0)
@@ -46,32 +46,31 @@ def test_add_neighbor(user, user2, login, client):
 def test_remove_neighbor(user, user2, login, client):
     """Should not return results (user 4 is also a provider and should not be returned)."""
     client.put(
-        f'user/add_neighbor',
-        json=dict(current_user_id=user.unique_identity, neighbor_id=user2.unique_identity),
+        f'user/add_neighbor/{user.id}',
+        json=dict(neighbor_id=user2.unique_identity),
         content_type="application/json"
     )
 
     client.put(
-        f'user/remove_neighbor',
-        json=dict(current_user_id=user.unique_identity, neighbor_id=user2.unique_identity),
+        f'user/remove_neighbor/{user.id}',
+        json=dict(neighbor_id=user2.unique_identity),
         content_type="application/json"
     )
 
     # Neighbors should be empty
     response = client.get(
-        f'user/neighbors/{user.unique_identity}'
+        f'user/neighbors/{user.id}'
     )
-    
+
     response_json = json.loads(response.data)
     assert(len(response_json) == 0)
 
     # Potential neighbors should be empty
     response = client.get(
-        f'user/nearby/{user.unique_identity}'
+        f'user/nearby/{user.id}'
     )
     response_json = json.loads(response.data)
     assert(len(response_json) == 0)
 
-    user_model = User.objects.get(unique_identity=user.unique_identity)
+    user_model = User.objects.get(id=user.id)
     assert(len(user_model.blacklisted_neighbors) == 1)
-


### PR DESCRIPTION
- Changed new neighbor routes to use user id instead of unique identity
- Frontend adds neighbor when chat starts
- Adjusted tests to match user id change